### PR TITLE
Fixed possible access to unallocated memory in MPRESS unpacker

### DIFF
--- a/src/unpackertool/plugins/mpress/mpress.cpp
+++ b/src/unpackertool/plugins/mpress/mpress.cpp
@@ -234,7 +234,7 @@ std::uint32_t MpressPlugin::getFixStub()
 void MpressPlugin::fixJumpsAndCalls(DynamicBuffer& buffer)
 {
 	std::uint32_t pos = 0;
-	std::uint32_t maxAddr = buffer.getRealDataSize() - 0x1000;
+	std::uint32_t maxAddr = std::max(0, static_cast<std::int32_t>(buffer.getRealDataSize()) - 0x1000);
 	while (pos < maxAddr)
 	{
 		std::uint32_t moveOffset = pos;


### PR DESCRIPTION
If the size of data is less than 0x1000 then we can possibly underflow unsigned int and access unallocated data.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix potential memory access issue in the MPRESS unpacker by adjusting the calculation of the maximum address to prevent underflow.

Bug Fixes:
- Prevent possible access to unallocated memory in the MPRESS unpacker by ensuring the buffer size does not underflow.

<!-- Generated by sourcery-ai[bot]: end summary -->